### PR TITLE
Remap 'expiration' to 'expires' when creating the AWS signature

### DIFF
--- a/src/createUrlSigner.js
+++ b/src/createUrlSigner.js
@@ -13,7 +13,7 @@ export default ({ region, endpoint, credentials }) => {
         key: credentials.accessKeyId,
         secret: credentials.secretAccessKey,
         region,
-        expiration,
+        expires: expiration,
         protocol: 'wss'
       }
     )


### PR DESCRIPTION
Fix for https://github.com/kmamykin/aws-mqtt/issues/9.

Remap 'expiration' to 'expires' when creating the AWS signature as this is the [property name expected by aws-signature-v4](https://github.com/department-stockholm/aws-signature-v4/blob/master/index.js#L165).